### PR TITLE
Replace std thread hardware_concurrency by system calls.

### DIFF
--- a/include/nanothread/nanothread.h
+++ b/include/nanothread/nanothread.h
@@ -70,7 +70,7 @@ pool_create(uint32_t size NANOTHREAD_DEF(NANOTHREAD_AUTO),
 extern NANOTHREAD_EXPORT void pool_destroy(Pool *pool NANOTHREAD_DEF(0));
 
 /// Returns the number of available CPU cores.
-extern NANOTHREAD_EXPORT uint32_t core_count() NANOTHREAD_THROW;
+extern NANOTHREAD_EXPORT uint32_t core_count();
 
 /**
  * \brief Return the number of threads that are part of the pool

--- a/include/nanothread/nanothread.h
+++ b/include/nanothread/nanothread.h
@@ -69,6 +69,9 @@ pool_create(uint32_t size NANOTHREAD_DEF(NANOTHREAD_AUTO),
  */
 extern NANOTHREAD_EXPORT void pool_destroy(Pool *pool NANOTHREAD_DEF(0));
 
+/// Returns the number of available CPU cores.
+extern NANOTHREAD_EXPORT uint32_t core_count() NANOTHREAD_THROW;
+
 /**
  * \brief Return the number of threads that are part of the pool
  *

--- a/src/nanothread.cpp
+++ b/src/nanothread.cpp
@@ -78,13 +78,13 @@ uint32_t core_count() {
 
 #if defined(__linux__)
     // Don't try to query CPU affinity if running inside Valgrind
-    if (getenv("VALGRIND_OPTS") == NULL) {
+    if (getenv("VALGRIND_OPTS") == nullptr) {
         /* Some of the cores may not be available to the user
            (e.g. on certain cluster nodes) -- determine the number
            of actual available cores here. */
         uint32_t ncores_logical = ncores;
         size_t size = 0;
-        cpu_set_t *cpuset = NULL;
+        cpu_set_t *cpuset = nullptr;
         int retval = 0;
 
         /* The kernel may expect a larger cpu_set_t than would


### PR DESCRIPTION
This ensures that the number of used threads corresponds to the number of threads available to the process, instead of the number of physical CPU cores/threads.

This function is actually simply imported from Mitsuba 3, where it already exists in `util.cpp`. It probably makes sense to have this logic moved to nanothread, so the entire system uses a consistent number of threads throughout. If we merge this, we can replace the corresponding function in mitsuba's util.cpp

