### PR TITLE
Add missing stdbool.h include for C compiler

### DIFF
--- a/include/nanothread/nanothread.h
+++ b/include/nanothread/nanothread.h
@@ -13,6 +13,10 @@
 #include <stddef.h>
 #include <stdio.h>
 
+#if !defined(__cplusplus)
+    #include <stdbool.h>
+#endif
+
 #if defined(_MSC_VER)
 #  if defined(NANOTHREAD_BUILD)
 #    define NANOTHREAD_EXPORT    __declspec(dllexport)


### PR DESCRIPTION
Hi,

It seems that with Clang 14, the compilation of test_01.c does not find the `bool` type used for the `stopping_criterion` argument to `pool_work_until`. What's missing is the include of `stdbool.h` in case the code is compiled using the C compiler.